### PR TITLE
Update script to show both live cats

### DIFF
--- a/doa.sh
+++ b/doa.sh
@@ -53,8 +53,12 @@ case ${NUM:$i} in
    dead
    exit 1
  ;;
- *)
+ [026])
   alive1
+  exit 0
+ ;;
+ [48])
+  alive2
   exit 0
  ;;
 esac


### PR DESCRIPTION
Seems sad to not show the second picture of the cat. The probability function remains the same for the live/dead split, only the choice of image varies.
